### PR TITLE
Misc

### DIFF
--- a/fighters/dedede/src/acmd/normals.rs
+++ b/fighters/dedede/src/acmd/normals.rs
@@ -2,7 +2,7 @@ use super::*;
 
 unsafe extern "C" fn game_attack11(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 1.0);
-    macros::FT_MOTION_RATE(agent, 2.0/3.0);
+    macros::FT_MOTION_RATE(agent, 4.0 / 6.0);
     frame(agent.lua_state_agent, 7.0);
     macros::FT_MOTION_RATE(agent, 1.0);
     frame(agent.lua_state_agent, 10.0);
@@ -13,10 +13,12 @@ unsafe extern "C" fn game_attack11(agent: &mut L2CAgentBase) {
         macros::ATTACK(agent, 3, 0, Hash40::new("top"), 4.0, 105, 10, 0, 48, 2.8, 0.0, 6.5, 19.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_dedede_hammer"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_DEDEDE, *ATTACK_REGION_HAMMER);
     }
     wait(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 5.0 / 7.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
     }
     frame(agent.lua_state_agent, 19.0);
+    macros::FT_MOTION_RATE(agent, 1.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
     }
@@ -24,11 +26,12 @@ unsafe extern "C" fn game_attack11(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_NO_HIT_COMBO);
     }
+    MiscModule::calc_motion_rate_from_cancel_frame(agent, 22.0, -5.0);
 }
 
 unsafe extern "C" fn game_attack12(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 1.0);
-    macros::FT_MOTION_RATE(agent, 0.75);
+    macros::FT_MOTION_RATE(agent, 6.0 / 8.0);
     frame(agent.lua_state_agent, 9.0);
     macros::FT_MOTION_RATE(agent, 1.0);
     frame(agent.lua_state_agent, 11.0);
@@ -43,7 +46,7 @@ unsafe extern "C" fn game_attack12(agent: &mut L2CAgentBase) {
         AttackModule::clear_all(agent.module_accessor);
     }
     frame(agent.lua_state_agent, 14.0);
-    macros::FT_MOTION_RATE(agent, 0.75);
+    macros::FT_MOTION_RATE(agent, 3.0 / 4.0);
     frame(agent.lua_state_agent, 18.0);
     macros::FT_MOTION_RATE(agent, 1.0);
     if macros::is_excute(agent) {

--- a/fighters/dedede/src/acmd/throws.rs
+++ b/fighters/dedede/src/acmd/throws.rs
@@ -2,7 +2,7 @@ use super::*;
 
 unsafe extern "C" fn game_throwlw(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
-        macros::ATTACK_ABS(agent, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 4.0, 20, 100, 70, 0, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        macros::ATTACK_ABS(agent, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 6.0, 80, 50, 0, 80, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         macros::ATTACK_ABS(agent, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(agent.lua_state_agent, 24.0);

--- a/fighters/dolly/src/acmd/specials.rs
+++ b/fighters/dolly/src/acmd/specials.rs
@@ -195,16 +195,8 @@ unsafe extern "C" fn game_specialsfattack(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn game_specialffeint(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        MotionModule::set_rate(agent.module_accessor, 1.0);
-        VarModule::off_flag(agent.module_accessor, vars::dolly::status::flag::SPECIAL_F_CHECK_FEINT);
-        WorkModule::on_flag(agent.module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_FLAG_DECIDE_STRENGTH);
-    }
     frame(agent.lua_state_agent, 7.0);
-    if macros::is_excute(agent) {
-        MotionModule::set_rate(agent.module_accessor, 0.75);
-    }
+    MiscModule::calc_motion_rate_from_cancel_frame(agent, 7.0, -3.0);
 }
 
 unsafe extern "C" fn effect_specialffeint(agent: &mut L2CAgentBase) {

--- a/fighters/dolly/src/status/special_s.rs
+++ b/fighters/dolly/src/status/special_s.rs
@@ -46,9 +46,6 @@ unsafe extern "C" fn special_s_main(fighter: &mut L2CFighterCommon) -> L2CValue 
 
     if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
         VarModule::on_flag(fighter.module_accessor, vars::dolly::status::flag::SPECIAL_F_CHECK_FEINT);
-        if fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_GUARD_TRIGGER != 0 {
-            VarModule::on_flag(fighter.module_accessor, vars::dolly::status::flag::SPECIAL_F_FEINT);
-        }
     }
 
     WorkModule::set_int(fighter.module_accessor, *FIGHTER_DOLLY_STRENGTH_S, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_INT_STRENGTH);
@@ -95,7 +92,7 @@ unsafe extern "C" fn special_s_main(fighter: &mut L2CFighterCommon) -> L2CValue 
 unsafe extern "C" fn special_s_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
     if !param_1.get_bool() {
         if VarModule::is_flag(fighter.module_accessor, vars::dolly::status::flag::SPECIAL_F_CHECK_FEINT)
-        && fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_GUARD_TRIGGER != 0 {
+        && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD) {
             VarModule::on_flag(fighter.module_accessor, vars::dolly::status::flag::SPECIAL_F_FEINT);
         }
     }

--- a/fighters/snake/src/acmd/aerials.rs
+++ b/fighters/snake/src/acmd/aerials.rs
@@ -111,15 +111,13 @@ unsafe extern "C" fn expression_attackairlw(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn game_attackairlw2(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
-        let speed_x = KineticModule::get_sum_speed_x(agent.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-        let lr = PostureModule::lr(agent.module_accessor);
-        macros::SET_SPEED_EX(agent, speed_x * lr * 0.3, 0.5, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        macros::SET_SPEED_EX(agent, 0.0, 0.65, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
     }
     frame(agent.lua_state_agent, 8.0);
     if macros::is_excute(agent) {
-        KineticModule::add_speed(agent.module_accessor, &Vector3f{x: 0.0, y: 0.8, z: 0.0});
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 90, 70, 35, 0, 5.5, 0.0, -1.0, 3.0, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 3.0, 90, 70, 35, 0, 4.5, 0.0, 5.0, 1.5, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        KineticModule::add_speed(agent.module_accessor, &Vector3f{x: 0.0, y: 0.65, z: 0.0});
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 366, 70, 35, 0, 5.5, 0.0, -1.0, 3.0, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 3.0, 366, 70, 35, 0, 4.5, 0.0, 5.0, 1.5, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
     wait(agent.lua_state_agent, 2.0);
     if macros::is_excute(agent) {
@@ -127,9 +125,9 @@ unsafe extern "C" fn game_attackairlw2(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 15.0);
     if macros::is_excute(agent) {
-        KineticModule::add_speed(agent.module_accessor, &Vector3f{x: 0.0, y: 0.8, z: 0.0});
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 90, 70, 35, 0, 5.5, 0.0, -1.0, 3.0, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 3.0, 90, 70, 35, 0, 4.5, 0.0, 5.0, 1.5, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        KineticModule::add_speed(agent.module_accessor, &Vector3f{x: 0.0, y: 0.65, z: 0.0});
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 366, 70, 35, 0, 5.5, 0.0, -1.0, 3.0, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 3.0, 366, 70, 35, 0, 4.5, 0.0, 5.0, 1.5, None, None, None, 0.7, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
     wait(agent.lua_state_agent, 2.0);
     if macros::is_excute(agent) {
@@ -137,14 +135,15 @@ unsafe extern "C" fn game_attackairlw2(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 23.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 70, 60, 0, 85, 7.0, 0.0, -1.0, 3.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 6.0, 70, 60, 0, 85, 6.0, 0.0, 5.0, 1.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        KineticModule::add_speed(agent.module_accessor, &Vector3f{x: 0.0, y: 1.7, z: 0.0});
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 70, 60, 0, 70, 7.0, 0.0, -1.0, 3.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 6.0, 70, 60, 0, 70, 6.0, 0.0, 5.0, 1.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
     wait(agent.lua_state_agent, 2.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
-        KineticModule::add_speed(agent.module_accessor, &Vector3f{x: 0.0, y: 1.7, z: 0.0});
     }
+    MiscModule::calc_motion_rate_from_cancel_frame(agent, 25.0, -7.0);
     frame(agent.lua_state_agent, 46.0);
     if macros::is_excute(agent) {
         WorkModule::off_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);

--- a/fighters/wolf/src/acmd/normals.rs
+++ b/fighters/wolf/src/acmd/normals.rs
@@ -50,11 +50,15 @@ unsafe extern "C" fn game_attack13(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn game_attackhi3(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 9.0);
+    frame(agent.lua_state_agent, 8.0);
+    macros::FT_MOTION_RATE(agent, 4.0 / 2.0);
+    frame(agent.lua_state_agent, 8.5);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("arml"), 8.0, 80, 110, 0, 40, 3.0, 3.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
-        macros::ATTACK(agent, 1, 0, Hash40::new("arml"), 8.0, 80, 110, 0, 40, 4.0, -1.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 0, 0, Hash40::new("arml"), 8.0, 80, 110, 0, 40, 3.0, 5.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 1, 0, Hash40::new("arml"), 8.0, 80, 110, 0, 40, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
     }
+    frame(agent.lua_state_agent, 10.0);
+    macros::FT_MOTION_RATE(agent, 1.0);
     frame(agent.lua_state_agent, 14.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
@@ -62,9 +66,10 @@ unsafe extern "C" fn game_attackhi3(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn effect_attackhi3(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 8.0);
+    frame(agent.lua_state_agent, 8.5);
     if macros::is_excute(agent) {
-        macros::EFFECT_FOLLOW(agent, Hash40::new("wolf_scratch_arc"), Hash40::new("top"), 3, 7.5, 0, 0, 70, 110, 0.9, true);
+        macros::EFFECT_FOLLOW(agent, Hash40::new("wolf_scratch_arc"), Hash40::new("top"), 3, 8.0, 0, 0, 70, 110, 0.95, true);
+        macros::LAST_EFFECT_SET_RATE(agent, 1.0);
     }
     frame(agent.lua_state_agent, 16.0);
     if macros::is_excute(agent) {

--- a/src/items/linkarrow.rs
+++ b/src/items/linkarrow.rs
@@ -1,3 +1,5 @@
+#![allow(integer_to_ptr_transmutes)]
+
 use crate::imports::*;
 use crate::system::func_links;
 

--- a/src/items/linkarrow.rs
+++ b/src/items/linkarrow.rs
@@ -1,4 +1,4 @@
-#![allow(integer_to_ptr_transmutes)]
+#![allow(unknown_lints, integer_to_ptr_transmutes)]
 
 use crate::imports::*;
 use crate::system::func_links;


### PR DESCRIPTION
# Changelog

## King Dedede

### Jab 1
Reduced the transition frame into Jab 2 by 2 frames.
Reduced overall endlag by 7 frames.

### Down Throw
Reverted Down Throw to a slightly adjusted version of vanilla.

## Snake

### Down Air
Snake's horizontal momentum is now stopped when the first stomp connects.
Stomps 2 and 3 now use a 366 angle.
Reduced height gained from each stomp.
Final stomp bkb reduced to keep opponents closer.
Endlag reduced to allow for true combos.

## Terry

### Burning Knuckle (Side Special / 214A)
The feint input can now be buffered by holding Shield.
Overall endlag on feint was reduced, though by how much I don't actually know.

## Wolf

### Up Tilt
The first active frame now starts lower than before.
Increased outwards range of the attack.