### PR TITLE
Engine Fixes

### DIFF
--- a/fighters/common/src/status/guard/guard.rs
+++ b/fighters/common/src/status/guard/guard.rs
@@ -175,8 +175,17 @@ unsafe extern "C" fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue 
     && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0
     && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
     && !ItemModule::is_have_item(fighter.module_accessor, 0) {
+        let stick_x = fighter.global_table[STICK_X].get_f32();
+        let lr = PostureModule::lr(fighter.module_accessor);
+        let turn_run_stick_x = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("turn_run_stick_x"));
+        let status = if stick_x * lr <= turn_run_stick_x {
+            FIGHTER_STATUS_KIND_CATCH_TURN
+        }
+        else {
+            FIGHTER_STATUS_KIND_CATCH
+        };
         // if !can_act {
-            fighter.change_status(FIGHTER_STATUS_KIND_CATCH.into(), true.into());
+            fighter.change_status(status.into(), true.into());
         // }
         // else {
         //     set_cat1_backup(fighter, *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH, false);

--- a/fighters/common/src/status/guard/guard_damage.rs
+++ b/fighters/common/src/status/guard/guard_damage.rs
@@ -119,7 +119,7 @@ unsafe extern "C" fn sub_ftstatusuniqprocessguarddamage_initstatus_inner(fighter
         facing_lr
     };
     if PostureModule::lr(fighter.module_accessor) != final_lr {
-        PostureModule::set_lr(fighter.module_accessor, facing_lr);
+        PostureModule::set_lr(fighter.module_accessor, final_lr);
         PostureModule::update_rot_y_lr(fighter.module_accessor);
     }
 

--- a/src/system/engine.rs
+++ b/src/system/engine.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn shield_set_facing_lr(ctx: &mut skyline::hooks::InlineCtx) {
     let fighter = ctx.registers[19].x() as *mut Fighter;
     let module_accessor = (*fighter).battle_object.module_accessor;
     let opponent_object_id = ctx.registers[23].w();
-    let dir = if opponent_object_id != *BATTLE_OBJECT_ID_INVALID as u32 {
+    let dir = if sv_battle_object::category(opponent_object_id) == *BATTLE_OBJECT_CATEGORY_FIGHTER {
         let opponent_module_accessor = sv_battle_object::module_accessor(opponent_object_id);
         let pos_x = PostureModule::pos_x(module_accessor);
         let opponent_pos_x = PostureModule::pos_x(opponent_module_accessor);


### PR DESCRIPTION
# Changelog

## Shield
- Restored the ability to perform a turnaround grab out of shield.
- Logic to determine facing direction when shield is hit has been adjusted.
  - You will always face the opponent if the hitbox is directly sourced from them.
  - You will face the opposite direction of shield pushback from all other sources.